### PR TITLE
fix: use relative paths for local components

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,14 +3,14 @@ import Link from "next/link";
 import { Suspense } from "react";
 
 // shadcn/ui (assuma instaladas)
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Badge } from "@/components/ui/badge";
-import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card";
+import { Button } from "../components/ui/button";
+import { Input } from "../components/ui/input";
+import { Badge } from "../components/ui/badge";
+import { Skeleton } from "../components/ui/skeleton";
 
 // Icons
-import { Search, MapPin, Mountain, Users, CalendarDays, ChevronRight } from "@/components/icons";
+import { Search, MapPin, Mountain, Users, CalendarDays, ChevronRight } from "../components/icons";
 
 // ====== Tipos ======
 export type CMSHomeHero = {


### PR DESCRIPTION
## Summary
- use relative paths to reference UI components and icons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c68b5d7883248e982107ef26beb3